### PR TITLE
Fully type arrays of structs

### DIFF
--- a/events/marshalling/fromjson/fromjson_test.go
+++ b/events/marshalling/fromjson/fromjson_test.go
@@ -39,7 +39,7 @@ func TestFromJSON(t *testing.T) {
 
 		actual, err := FromJSON(data)
 		require.NoError(t, err)
-		require.True(t, len(actual) > 2)
+		require.True(t, len(actual) > 2, "no type generated: %s", actual)
 
 		// NOTE: Golang maps do not retain any order.  This means that the
 		// values are bound to be different on each test run.  We figure out
@@ -59,11 +59,14 @@ func TestFromJSON(t *testing.T) {
 			fmt.Println(actual)
 		}
 
-		require.True(t, matches, "generated types do not match")
+		require.True(t, matches, "generated types do not match (got %s)", actual)
 
 		// Ensure B also subsumes A so that they're the same.
 		matches = instB.Value().Subsumes(instA.Value())
-		require.True(t, matches, "generated types do not match")
+		if !matches {
+			fmt.Println(actual)
+		}
+		require.True(t, matches, "generated types do not reverse-match (got %s)", actual)
 	}
 }
 

--- a/events/marshalling/fromjson/testdata/array_of_structs.cue
+++ b/events/marshalling/fromjson/testdata/array_of_structs.cue
@@ -1,0 +1,19 @@
+{
+	array: [...{
+		id: string
+		ok: bool
+	}]
+	mixed_array: [...{
+		id:     string
+		number: float
+		ok:     bool
+	} | {
+		id:     string
+		number: int
+		ok:     bool
+	} | {
+		id:          string
+		number:      float
+		another_str: string
+	}]
+}

--- a/events/marshalling/fromjson/testdata/array_of_structs.json
+++ b/events/marshalling/fromjson/testdata/array_of_structs.json
@@ -1,0 +1,14 @@
+{
+  "array": [
+    { "id": "1", "ok": true },
+    { "id": "2", "ok": true },
+    { "id": "3", "ok": false },
+    { "id": "4", "ok": true }
+  ],
+  "mixed_array": [
+    { "id": "1", "number": 1.2, "ok": true },
+    { "id": "2", "number": 8.2, "ok": true },
+    { "id": "3", "number": 4, "ok": true },
+    { "id": "4", "number": 1.2, "another_str": "lol" }
+  ]
+}

--- a/events/marshalling/jsonschema/jsonschema.go
+++ b/events/marshalling/jsonschema/jsonschema.go
@@ -67,7 +67,7 @@ func MarshalCueValue(v cue.Value) (map[string]interface{}, error) {
 
 // Schemas stores all schemas generated for a cue file.
 type Schemas struct {
-	// All stores all generated schemas, in a
+	// All stores all generated schemas, in a map.
 	All map[string]map[string]interface{}
 }
 


### PR DESCRIPTION
Input:

```json
{
  "array": [
    { "id": "1", "ok": true },
    { "id": "2", "ok": true },
    { "id": "3", "ok": false },
    { "id": "4", "ok": true }
  ],
  "mixed_array": [
    { "id": "1", "number": 1.2, "ok": true },
    { "id": "2", "number": 8.2, "ok": true },
    { "id": "3", "number": 4, "ok": true },
    { "id": "4", "number": 1.2, "another_str": "lol" }
  ]
}
```

Before:
```
{
  array: [...{...}]
  mixed_array: [...{...}]
}
```


After:
```
{
	array: [...{
		id: string
		ok: bool
	}]
	mixed_array: [...{
		id:     string
		number: float
		ok:     bool
	} | {
		id:     string
		number: int
		ok:     bool
	} | {
		id:          string
		number:      float
		another_str: string
	}]
}
```