### PR TITLE
Type merging

### DIFF
--- a/events/marshalling/fromjson/fromjson.go
+++ b/events/marshalling/fromjson/fromjson.go
@@ -228,7 +228,7 @@ NEXT:
 		// Does this match any existing struct type?
 		for _, existing := range deduped {
 			// XXX: Store these mapped to process once.
-			instB, _ := astToValue(r, existing)
+			instB, _ := cueutil.ASTToValue(r, existing)
 
 			subA := instA.Value().Subsumes(instB.Value())
 			subB := instB.Value().Subsumes(instA.Value())

--- a/events/marshalling/fromjson/fromjson.go
+++ b/events/marshalling/fromjson/fromjson.go
@@ -8,6 +8,7 @@ import (
 	"cuelang.org/go/cue/ast"
 	"cuelang.org/go/cue/format"
 	"cuelang.org/go/cue/token"
+	"github.com/inngest/event-schemas/pkg/cueutil"
 )
 
 // FromJSON takes a JSON map and generates a CUE type which validates the given
@@ -222,7 +223,7 @@ NEXT:
 		// We ignore errors as this is best-effort.  Worst case we return
 		// no concrete struct definitions and use the top-level {...}
 		// struct identifier for any key/values.
-		instA, _ := astToValue(r, next)
+		instA, _ := cueutil.ASTToValue(r, next)
 
 		// Does this match any existing struct type?
 		for _, existing := range deduped {
@@ -275,18 +276,4 @@ func kind(v interface{}) cue.Kind {
 	}
 
 	return cue.TopKind
-}
-
-func astToValue(r *cue.Runtime, ast ast.Node) (cue.Value, error) {
-	// Format the cue code.
-	byt, _ := format.Node(
-		ast,
-		format.TabIndent(false),
-		format.UseSpaces(2),
-	)
-	inst, err := r.Compile(".", byt)
-	if err != nil {
-		return cue.Value{}, err
-	}
-	return inst.Value(), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/inngest/cuetypescript v0.0.0-20220302153725-a00e933fdf87
 	github.com/inngest/golorem v0.0.0-20220323014825-15bf7a53bf79
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/tools v0.0.0-20200612220849-54c614fe050c
 )
 
 require (

--- a/pkg/cueutil/cueutil.go
+++ b/pkg/cueutil/cueutil.go
@@ -1,0 +1,37 @@
+package cueutil
+
+import (
+	"fmt"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/ast"
+	"cuelang.org/go/cue/format"
+)
+
+// ASTToValue converst cue AST to a cue.Value using the given runtime.
+func ASTToValue(r *cue.Runtime, ast ast.Node) (cue.Value, error) {
+	// Format the cue code.
+	str, err := ASTToSyntax(ast)
+	if err != nil {
+		return cue.Value{}, err
+	}
+	inst, err := r.Compile(".", str)
+	if err != nil {
+		fmt.Println(str)
+		return cue.Value{}, fmt.Errorf("error converting node to value: %w", err)
+	}
+
+	return inst.Value(), nil
+}
+
+func ASTToSyntax(ast ast.Node) (string, error) {
+	byt, err := format.Node(
+		ast,
+		format.TabIndent(false),
+		format.UseSpaces(2),
+	)
+	if err != nil {
+		return "", fmt.Errorf("error converting node to syntax: %w", err)
+	}
+	return string(byt), nil
+}

--- a/pkg/merge/merge.go
+++ b/pkg/merge/merge.go
@@ -1,0 +1,316 @@
+package merge
+
+import (
+	"context"
+	"fmt"
+
+	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/ast"
+	"github.com/inngest/event-schemas/pkg/cueutil"
+)
+
+// Merge merges two cue Values, returning a fully formatted cue Value which represents
+// the merged definition.
+func Merge(ctx context.Context, a, b cue.Value) (cue.Value, error) {
+	merged, err := recursivelyMerge(ctx, a, b)
+	if err != nil {
+		return merged, err
+	}
+
+	merged, err = recursivelyMerge(ctx, b, merged)
+	if err != nil {
+		return merged, err
+	}
+
+	return merged, nil
+}
+
+func recursivelyMerge(ctx context.Context, a, b cue.Value) (cue.Value, error) {
+	// If one of the values is BottomKind it has no data, so we can return
+	// the other value immediately.
+	if b.IncompleteKind() == cue.BottomKind {
+		return a, nil
+	}
+	if a.IncompleteKind() == cue.BottomKind {
+		return b, nil
+	}
+
+	r := &cue.Runtime{}
+
+	// Build a new struct which will contain merged fields from A and B.
+	def := &ast.StructLit{}
+
+	// Iterate through A, grabbing fields from B.  We'll compare each field in
+	// A to the fields in B, merging the values together.
+	it, err := a.Fields(
+		cue.All(),
+		cue.Definitions(true),
+		cue.Concrete(false),
+	)
+	if err != nil {
+		return cue.Value{}, fmt.Errorf("error returning fields of a: %w", err)
+	}
+
+	// The general strategy is to:
+	//
+	// 1. Store a list of values - referring to type defintions - in A and B
+	// 2. Dedupe the list
+	// 3. Return a value referrnig to each type defintion left in the list.  If the
+	//    list has a single value we can return the single value overall.  Else, we
+	//    return a union of the values using a BinaryOp AST.
+	//
+	// There are two special cases:  structs and slices.
+	//
+	// If we're merging two single structs together, we recursively loop through each
+	// field and merge the definitions together.  This is a special case.
+	//
+	// If we're merging slices together, we always create a binary op.
+
+	for it.Next() {
+		label := it.Label()
+
+		aValue := it.Value()
+		// Get the AST for the field in A, which is always an *ast.Field.
+		aValAsField := aValue.Source().(*ast.Field)
+
+		// Look the field up to check whether it's a member of the second struct B.
+		// If it isn't found on the other struct, we can safely use A's field as-is.
+		bField, _ := b.FieldByName(label, true)
+		bValue := bField.Value
+
+		if bValue.IncompleteKind() == cue.BottomKind {
+			// Use A immediately, as there is no field in B.  Mark this field as
+			// optional as it's only usable in one of the definitions.
+			// TODO OPTIONAL
+			def.Elts = append(def.Elts, aValAsField)
+			continue
+		}
+
+		bValAsField := bValue.Source().(*ast.Field)
+
+		// Get all values for the field, expanding the binary tree of unions into a
+		// list of vales.
+		aValues, err := expandValues(r, aValue)
+		if err != nil {
+			return cue.Value{}, err
+		}
+		bValues, err := expandValues(r, bValue)
+		if err != nil {
+			return cue.Value{}, err
+		}
+
+		// If we have one value each - and they're both structs - we need to recursively
+		// merge these structs together into a single struct, containing optional fields
+		// for values only represented in one.
+		//
+		// XXX (tonyhb): We could have a strategy which recursively merges _and_ returns
+		// metadata about the similarities of structs.  We can then use this metadata to
+		// determine whether to use a binary expression (eg. structs contain no overlap)
+		// or to use the merged struct altogether.
+
+		if len(aValues) <= 1 && len(bValues) <= 1 {
+			// If the types are of different kinds we can immediately create a union
+			// of the type definitions.
+			if aValue.IncompleteKind() != bValue.IncompleteKind() {
+				def.Elts = append(def.Elts, &ast.Field{
+					Label: ast.NewIdent(label),
+					Value: union(aValAsField.Value, bValAsField.Value),
+				})
+				continue
+			}
+
+			// If the values are of the same scalar kind, use the values from A.
+			if scalarEquals(aValue.IncompleteKind(), bValue.IncompleteKind()) {
+				// XXX (tonyhb): Are these concrete values?  If so, should we make an enum of
+				// strings?
+				//
+				// The fields are the same scalar kind, so we can continue.
+				def.Elts = append(def.Elts, aValAsField)
+				continue
+			}
+
+			// If we're merging two structs together, recursively merge each member.
+			if aValue.IncompleteKind() == cue.StructKind && bValue.IncompleteKind() == cue.StructKind {
+				// Merge fields of the same complex kind recursively, eg. merge
+				// two struct fields together into a new struct.
+				next, err := recursivelyMerge(ctx, aValue, bValue)
+				if err != nil {
+					return cue.Value{}, err
+				}
+
+				switch src := next.Source().(type) {
+				case *ast.Field:
+					// We're returned an *ast.Field directly
+					def.Elts = append(def.Elts, src)
+					continue
+				case *ast.File:
+					// This is an *ast.File, as it's entirely formatted by cueutil.ASTToValue.
+					// Pull put the declaration from the file.
+					expr := next.Source().(*ast.File).Decls[0].(*ast.EmbedDecl).Expr
+					def.Elts = append(def.Elts, &ast.Field{
+						Label: ast.NewIdent(label),
+						Value: expr,
+					})
+				default:
+					return cue.Value{}, fmt.Errorf("unknown source kind for struct: %T", src)
+				}
+
+				// Continue on to the next field
+				continue
+			}
+
+			// We're only left with merging slices.  This uses the same logic as merging >
+			// 1 item from each value:  we're almost always goign to create a binary op
+			// for the slice and deduplicate the op.
+		}
+
+		// Store a map of values we've seen.  The only way to do this nicely is
+		// to format the AST into a well defined string.
+		seen := map[string]struct{}{}
+		deduped := []ast.Expr{}
+		for _, item := range append(aValues, bValues...) {
+			code, err := cueutil.ASTToSyntax(item.Source())
+			if err != nil {
+				return cue.Value{}, err
+			}
+
+			if _, ok := seen[code]; ok {
+				continue
+			}
+
+			seen[code] = struct{}{}
+
+			switch src := item.Source().(type) {
+			case *ast.Field:
+				deduped = append(deduped, src.Value)
+			case *ast.File:
+				deduped = append(deduped, src.Decls[0].(*ast.EmbedDecl).Expr)
+			default:
+				return cue.Value{}, fmt.Errorf("unknown ast type deduplicating value: %T", src)
+			}
+		}
+
+		// Return a field containing all items.
+		def.Elts = append(def.Elts, &ast.Field{
+			Label: ast.NewIdent(label),
+			Value: union(deduped...),
+		})
+		continue
+	}
+
+	// We may have missed fields from B that were missing in A.  Iterate through all of B's
+	// fields and check which ones haven't been merged.
+	it, err = b.Fields(
+		cue.All(),
+		cue.Definitions(true),
+		cue.Concrete(false),
+	)
+	if err != nil {
+		return cue.Value{}, fmt.Errorf("error returning fields for b: %w", err)
+	}
+	for it.Next() {
+		label := it.Label()
+		if a.LookupPath(cue.ParsePath(label)).IncompleteKind() != cue.BottomKind {
+			// This field was found;  skip.
+			continue
+		}
+
+		// This field isn't present in A, so it was skipped.  We can add this directly
+		// to our struct.
+		val := it.Value()
+		aValAsField := val.Source().(*ast.Field)
+		def.Elts = append(def.Elts, aValAsField)
+	}
+
+	return cueutil.ASTToValue(r, def)
+}
+
+// union merges all expressions into a single branched binary expression.
+func union(elts ...ast.Expr) ast.Expr {
+	if len(elts) == 1 {
+		return elts[0]
+	}
+
+	current := &ast.BinaryExpr{
+		Op: cue.OrOp.Token(),
+	}
+	for len(elts) > 0 {
+		elt := elts[0]
+		elts = elts[1:]
+
+		current.X = elt
+		if len(elts) == 1 {
+			// The last item goes in the final branch.
+			current.Y = elts[0]
+			elts = elts[1:]
+			continue
+		}
+
+		current.Y = &ast.BinaryExpr{
+			Op: cue.OrOp.Token(),
+		}
+		current = current.Y.(*ast.BinaryExpr)
+	}
+	return current
+}
+
+func expandValues(r *cue.Runtime, union cue.Value) ([]cue.Value, error) {
+	if union, ok := union.Syntax().(*ast.BinaryExpr); ok {
+		vals := []cue.Value{}
+		for _, expr := range expand(union) {
+			val, err := cueutil.ASTToValue(r, expr)
+			if err != nil {
+				return vals, err
+			}
+			vals = append(vals, val)
+		}
+		return vals, nil
+	}
+	return []cue.Value{union}, nil
+}
+
+// expand walks a BinaryExpr, returning every non-binary expr as a single slice.
+func expand(union *ast.BinaryExpr) []ast.Expr {
+	result := []ast.Expr{}
+
+	stack := []*ast.BinaryExpr{union}
+	for len(stack) > 0 {
+		item := stack[0]
+		stack = stack[1:]
+
+		if union, ok := item.X.(*ast.BinaryExpr); ok {
+			stack = append(stack, union)
+		} else {
+			result = append(result, item.X)
+		}
+
+		if union, ok := item.Y.(*ast.BinaryExpr); ok {
+			stack = append(stack, union)
+		} else {
+			result = append(result, item.Y)
+		}
+	}
+
+	return result
+}
+
+func isScalar(k cue.Kind) bool {
+	return k != cue.StructKind && k != cue.ListKind
+}
+
+func scalarEquals(a, b cue.Kind) bool {
+	if !isScalar(a) || !isScalar(b) {
+		// Structs and arrays can never be the same by shallowc comparisons;  they may
+		// have different members.
+		return false
+	}
+	return a == b
+}
+
+func equals(a, b cue.Value) bool {
+	// If A or B is a slice, we can't use subsumes as it's buggy:  a slice of one type
+	// subsumes a slice of another.
+	//
+	// See https://github.com/cue-lang/cue/issues/1654 for more info.
+	return (a.Subsume(b, cue.All()) == nil || b.Subsume(a, cue.All()) == nil) && (a.Unify(b).Kind() != cue.BottomKind)
+}

--- a/pkg/merge/merge_test.go
+++ b/pkg/merge/merge_test.go
@@ -19,7 +19,7 @@ func TestMerge(t *testing.T) {
 	require.NoError(t, err)
 
 	// Allows us to focus on a specfic test name.
-	focus := ""
+	focus := "missing_field.txtar"
 
 	for _, e := range entries {
 		t.Run(e.Name(), func(t *testing.T) {

--- a/pkg/merge/merge_test.go
+++ b/pkg/merge/merge_test.go
@@ -1,0 +1,86 @@
+package merge
+
+import (
+	"context"
+	"log"
+	"os"
+	"path"
+	"strings"
+	"testing"
+
+	"cuelang.org/go/cue"
+	"github.com/inngest/event-schemas/pkg/cueutil"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/tools/txtar"
+)
+
+func TestMerge(t *testing.T) {
+	entries, err := os.ReadDir("./testdata")
+	require.NoError(t, err)
+
+	// Allows us to focus on a specfic test name.
+	focus := ""
+
+	for _, e := range entries {
+		t.Run(e.Name(), func(t *testing.T) {
+			if !strings.HasSuffix(e.Name(), ".txtar") {
+				return
+			}
+
+			// NOTE: Until https://github.com/cue-lang/cue/issues/1654 is fixed, we cannot
+			// test the merging of slices due to an internal Cue bug.
+			if e.Name() == "slices.txtar" {
+				return
+			}
+
+			if focus != "" && e.Name() != focus {
+				return
+			}
+
+			archive, err := txtar.ParseFile(path.Join("./testdata", e.Name()))
+			if err != nil {
+				log.Fatal(err)
+			}
+
+			r := &cue.Runtime{}
+
+			var expected []byte
+			var actual cue.Value
+			for _, f := range archive.Files {
+				if f.Name == "expected" {
+					expected = f.Data
+					continue
+				}
+
+				// Add the thingy to a mergy.
+				inst, err := r.Compile(".", f.Data)
+				require.NoError(t, err)
+				actual, err = Merge(context.Background(), inst.Value(), actual)
+				require.NoError(t, err)
+			}
+
+			// Parse expected and actual.
+			instA, err := r.Compile(".", expected)
+			require.NoError(t, err)
+			expectedVal := instA.Value()
+
+			// Format the expected syntax nicely
+			expectedSyntax, err := cueutil.ASTToSyntax(expectedVal.Syntax())
+			require.NoError(t, err)
+
+			// for naming consistency
+			actualVal := actual
+			syntax, err := cueutil.ASTToSyntax(actualVal.Syntax())
+			require.NoError(t, err)
+
+			matches := expectedVal.Subsumes(actualVal)
+
+			require.True(t, matches, "generated types do not match.  got: \n%s\nexpected:\n%s", syntax, expectedSyntax)
+
+			// Ensure actual also subsumes expected so that they're the same.
+			matches = actualVal.Subsumes(expectedVal)
+			require.True(t, matches, "generated types do not reverse-match.  got: \n%s\nexpected:\n%s", syntax, expectedSyntax)
+		})
+	}
+
+}

--- a/pkg/merge/testdata/equal.txtar
+++ b/pkg/merge/testdata/equal.txtar
@@ -1,0 +1,12 @@
+-- a.cue --
+{
+  name: string
+}
+-- b.cue --
+{
+  name: string
+}
+-- expected --
+{
+  name: string
+}

--- a/pkg/merge/testdata/merge_scalar_types.txtar
+++ b/pkg/merge/testdata/merge_scalar_types.txtar
@@ -1,0 +1,22 @@
+-- a.cue --
+{
+  mixed: string
+  nested: {
+    nested_mixed: bool
+  }
+}
+-- b.cue --
+{
+  mixed: int
+  nested: {
+    nested_mixed: float
+  }
+}
+-- expected --
+{
+  mixed: string | int
+  nested: {
+    nested_mixed: bool | float
+  }
+}
+

--- a/pkg/merge/testdata/missing_field.txtar
+++ b/pkg/merge/testdata/missing_field.txtar
@@ -14,11 +14,11 @@
 }
 -- expected --
 {
-  name: string
-  another: int
+  name?: string
+  another?: int
   nested: {
-    a: bool
-    b: float
+    a?: bool
+    b?: float
   }
 }
 

--- a/pkg/merge/testdata/missing_field.txtar
+++ b/pkg/merge/testdata/missing_field.txtar
@@ -1,0 +1,24 @@
+-- a.cue --
+{
+  name: string
+  nested: {
+    a: bool
+  }
+}
+-- b.cue --
+{
+  another: int
+  nested: {
+    b: float
+  }
+}
+-- expected --
+{
+  name: string
+  another: int
+  nested: {
+    a: bool
+    b: float
+  }
+}
+

--- a/pkg/merge/testdata/slices.txtar
+++ b/pkg/merge/testdata/slices.txtar
@@ -1,0 +1,41 @@
+-- a.cue --
+{
+  name:             string
+  a_str_slice:      [...string]
+  common_str_slice: [...string]
+
+  diff_slice:           [...string]
+  complex_slice:        [...{ a: string }]
+  complex_binary_slice: [...({ a: string } | string)]
+
+  // this has multiple, but b has single float.
+  multi_merge: [...string]
+}
+
+-- b.cue --
+{
+  name:             string
+  b_str_slice:      [...string]
+  common_str_slice: [...string]
+
+  diff_slice:           [...int]
+  complex_slice:        [...{ b: string }]
+  complex_binary_slice: [...int]
+
+  // attempt a slice that only has a float
+  multi_merge: [float]
+}
+
+-- expected --
+{
+  name: string
+  a_str_slice: [...string]
+  b_str_slice: [...string]
+  common_str_slice: [...string]
+
+  diff_slice:           [...string] | [...int]
+  complex_slice:        [...{ a: string }] | [...{ b: string }]
+  complex_binary_slice: [...({ a: string } | string)] | [...int]
+
+  multi_merge: [...string] | [float]
+}

--- a/vendor/golang.org/x/tools/AUTHORS
+++ b/vendor/golang.org/x/tools/AUTHORS
@@ -1,0 +1,3 @@
+# This source code refers to The Go Authors for copyright purposes.
+# The master list of authors is in the main Go distribution,
+# visible at http://tip.golang.org/AUTHORS.

--- a/vendor/golang.org/x/tools/CONTRIBUTORS
+++ b/vendor/golang.org/x/tools/CONTRIBUTORS
@@ -1,0 +1,3 @@
+# This source code was written by the Go contributors.
+# The master list of contributors is in the main Go distribution,
+# visible at http://tip.golang.org/CONTRIBUTORS.

--- a/vendor/golang.org/x/tools/LICENSE
+++ b/vendor/golang.org/x/tools/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/tools/PATENTS
+++ b/vendor/golang.org/x/tools/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/tools/txtar/archive.go
+++ b/vendor/golang.org/x/tools/txtar/archive.go
@@ -1,0 +1,140 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package txtar implements a trivial text-based file archive format.
+//
+// The goals for the format are:
+//
+//	- be trivial enough to create and edit by hand.
+//	- be able to store trees of text files describing go command test cases.
+//	- diff nicely in git history and code reviews.
+//
+// Non-goals include being a completely general archive format,
+// storing binary data, storing file modes, storing special files like
+// symbolic links, and so on.
+//
+// Txtar format
+//
+// A txtar archive is zero or more comment lines and then a sequence of file entries.
+// Each file entry begins with a file marker line of the form "-- FILENAME --"
+// and is followed by zero or more file content lines making up the file data.
+// The comment or file content ends at the next file marker line.
+// The file marker line must begin with the three-byte sequence "-- "
+// and end with the three-byte sequence " --", but the enclosed
+// file name can be surrounding by additional white space,
+// all of which is stripped.
+//
+// If the txtar file is missing a trailing newline on the final line,
+// parsers should consider a final newline to be present anyway.
+//
+// There are no possible syntax errors in a txtar archive.
+package txtar
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"strings"
+)
+
+// An Archive is a collection of files.
+type Archive struct {
+	Comment []byte
+	Files   []File
+}
+
+// A File is a single file in an archive.
+type File struct {
+	Name string // name of file ("foo/bar.txt")
+	Data []byte // text content of file
+}
+
+// Format returns the serialized form of an Archive.
+// It is assumed that the Archive data structure is well-formed:
+// a.Comment and all a.File[i].Data contain no file marker lines,
+// and all a.File[i].Name is non-empty.
+func Format(a *Archive) []byte {
+	var buf bytes.Buffer
+	buf.Write(fixNL(a.Comment))
+	for _, f := range a.Files {
+		fmt.Fprintf(&buf, "-- %s --\n", f.Name)
+		buf.Write(fixNL(f.Data))
+	}
+	return buf.Bytes()
+}
+
+// ParseFile parses the named file as an archive.
+func ParseFile(file string) (*Archive, error) {
+	data, err := ioutil.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	return Parse(data), nil
+}
+
+// Parse parses the serialized form of an Archive.
+// The returned Archive holds slices of data.
+func Parse(data []byte) *Archive {
+	a := new(Archive)
+	var name string
+	a.Comment, name, data = findFileMarker(data)
+	for name != "" {
+		f := File{name, nil}
+		f.Data, name, data = findFileMarker(data)
+		a.Files = append(a.Files, f)
+	}
+	return a
+}
+
+var (
+	newlineMarker = []byte("\n-- ")
+	marker        = []byte("-- ")
+	markerEnd     = []byte(" --")
+)
+
+// findFileMarker finds the next file marker in data,
+// extracts the file name, and returns the data before the marker,
+// the file name, and the data after the marker.
+// If there is no next marker, findFileMarker returns before = fixNL(data), name = "", after = nil.
+func findFileMarker(data []byte) (before []byte, name string, after []byte) {
+	var i int
+	for {
+		if name, after = isMarker(data[i:]); name != "" {
+			return data[:i], name, after
+		}
+		j := bytes.Index(data[i:], newlineMarker)
+		if j < 0 {
+			return fixNL(data), "", nil
+		}
+		i += j + 1 // positioned at start of new possible marker
+	}
+}
+
+// isMarker checks whether data begins with a file marker line.
+// If so, it returns the name from the line and the data after the line.
+// Otherwise it returns name == "" with an unspecified after.
+func isMarker(data []byte) (name string, after []byte) {
+	if !bytes.HasPrefix(data, marker) {
+		return "", nil
+	}
+	if i := bytes.IndexByte(data, '\n'); i >= 0 {
+		data, after = data[:i], data[i+1:]
+	}
+	if !bytes.HasSuffix(data, markerEnd) {
+		return "", nil
+	}
+	return strings.TrimSpace(string(data[len(marker) : len(data)-len(markerEnd)])), after
+}
+
+// If data is empty or ends in \n, fixNL returns data.
+// Otherwise fixNL returns a new slice consisting of data with a final \n added.
+func fixNL(data []byte) []byte {
+	if len(data) == 0 || data[len(data)-1] == '\n' {
+		return data
+	}
+	d := make([]byte, len(data)+1)
+	copy(d, data)
+	d[len(data)] = '\n'
+	return d
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -134,6 +134,9 @@ golang.org/x/text/secure/bidirule
 golang.org/x/text/transform
 golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
+# golang.org/x/tools v0.0.0-20200612220849-54c614fe050c
+## explicit; go 1.11
+golang.org/x/tools/txtar
 # golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 ## explicit; go 1.11
 golang.org/x/xerrors


### PR DESCRIPTION
Allow two cue definitions to be recursively merged into a single definition.  This helps fix https://github.com/inngest/typedwebhook.tools/issues/21, as well as improve our built-in event schemas by ensuring that type definitions are generated correctly for many payloads.